### PR TITLE
Update SQL Server CU info and streamline documentation

### DIFF
--- a/docs/concise wrap-up.md
+++ b/docs/concise wrap-up.md
@@ -7,14 +7,14 @@ nav_order: 2
 
 ## SQL Server 2022 CU22 (KB5068450) – November 2025
 
-| Item                              | Value                                                                                                                                                                                         |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Release Date**            | 18 November 2025                                                                                                                                                                                  |
-| **Build**                   | 16.0.4225.2                                                                                                                                                                                   |
-| **Analysis Services Build** | 16.0.43.252                                                                                                                                                                                   |
-| **Fixes**                   | cumulative fixes (detailed in the [official KB](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate22)) |
-| **Known Issue**             | `SESSION_CONTEXT` may return wrong results or AV dumps under **parallel plans**.                                                                                                      |
-| **Link**                    | [https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate22](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate22)   |
+| Item                              | Value                                                                                                                                                                                       |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Release Date**            | 18 November 2025                                                                                                                                                                            |
+| **Build**                   | 16.0.4225.2                                                                                                                                                                                 |
+| **Analysis Services Build** | 16.0.43.252                                                                                                                                                                                 |
+| **Fixes**                   | cumulative fixes (detailed in the[official KB](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate22))                                                 |
+| **Known Issue**             | `SESSION_CONTEXT` may return wrong results or AV dumps under **parallel plans**.                                                                                                    |
+| **Link**                    | [https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate22](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate22) |
 
 ## Google Cloud Marketplace Image
 
@@ -27,42 +27,19 @@ nav_order: 2
 | **Instance Name** | `SQLEXPRESS`                                          |
 | **Clustered**     | No                                                      |
 
-## SQL Server 2022 CU20 (KB5059390) – July 2025
-
-| Item                              | Value                                                                                                                                                                                         |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Release Date**            | 10 July 2025                                                                                                                                                                                  |
-| **Build**                   | 16.0.4205.1                                                                                                                                                                                   |
-| **Analysis Services Build** | 16.0.43.247                                                                                                                                                                                   |
-| **Fixes**                   | 10 cumulative fixes (detailed in the [official KB](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate20#improvements-and-fixes-included-in-this-update)) |
-| **Known Issue**             | `SESSION_CONTEXT` may return wrong results or AV dumps under **parallel plans**.                                                                                                      |
-| **Link**                    | [https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate20](https://learn.microsoft.com/en-us/troubleshoot/sql/releases/sqlserver-2022/cumulativeupdate20)   |
-
-## Google Cloud Marketplace Image
-
-| Item                    | Value                                                   |
-| ----------------------- | ------------------------------------------------------- |
-| **OS**            | Windows Server 2022 Datacenter (10.0.20348)             |
-| **SQL Edition**   | **Express** RTM-CU20 (KB5059390)                  |
-| **Version**       | 16.0.4205.1                                             |
-| **Features**      | Database Engine, Replication, Machine Learning Services |
-| **Instance Name** | `SQLEXPRESS`                                          |
-| **Clustered**     | No                                                      |
-
 ## Post-deployment Checklist on GCP
 
 1. Enable TCP/IP & Set Port
 
    - SQL Config Mgr → SQL Server Network Config → Protocols for SQLEXPRESS
    - IPAll → TCP Port = 1433
-
 2. Firewall Rules
 
    - TCP 1433 (SQL Server)
    - UDP 1434 (SQL Browser)
 
    > Already pre-configured in the image.
-
+   >
 3. Connect
 
    - SSMS: WIN-AUTH to .\SQLEXPRESS
@@ -71,14 +48,12 @@ nav_order: 2
    ```cmd
        sqlcmd -S .\SQLEXPRESS
    ```
-
 4. Verify
 
    ```sql
        SELECT @@VERSION;   -- should show CU22
        GO
    ```
-
 5. Add sysadmin (if needed)
 
    ```sql


### PR DESCRIPTION
Removed details for SQL Server 2022 CU20 and its Google Cloud image, retaining only CU22 information. Cleaned up formatting and reduced redundancy in the post-deployment checklist for clarity.